### PR TITLE
Fix the HTML escaping of > and < characters in pre.

### DIFF
--- a/bin/pre
+++ b/bin/pre
@@ -4,7 +4,7 @@ ${@:1} > $TMP_FILE
 RES=$?
 if [ -s $TMP_FILE ]; then
   echo "<pre>"
-  cat $TMP_FILE | sed 's/</\&lt;/g; s/>/\&gt;/g; s/\&/\&amp;/g'
+  cat $TMP_FILE | sed 's/\&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g'
   echo "</pre>"
 fi
 rm $TMP_FILE


### PR DESCRIPTION
The old version double escaped the `>` and `<` characters. The output was like `&amp;gt;` when `&gt;` is expected.