### PR TITLE
Set error and empty feedback file if it is too large

### DIFF
--- a/bin/grade
+++ b/bin/grade
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+# MOOC-Grader has the Django variable settings.DATA_UPLOAD_MAX_MEMORY_SIZE set to 10*1024*1024 (10MB).
+# Therefore, the grading containers have a maximum feedback size of 9*1024*1024 (9MB).
+# The remaining 1MB is allocated for data, such as sid, points, max_points, and grading_data (errors visible to staff).
+MAX_FEEDBACK_SIZE=$((9*1024*1024))
+
 feedback_file=/dev/shm/feedback
 grading_data_file=/dev/shm/grading_data
 opts=""
@@ -84,6 +90,15 @@ collect_feedback() {
             echo '</div>'
         fi
     ) > $feedback_file
+
+    feedback_size=$(stat -c%s "$feedback_file")
+
+    # Empty the feedback file if it is too large
+    if [ $feedback_size -gt $MAX_FEEDBACK_SIZE ]; then
+        > $feedback_file
+        opts="$opts -F feedback_size_error=true"
+    fi
+
     opts="$opts -F feedback=<$feedback_file"
 }
 


### PR DESCRIPTION
# Description

**What?**

If the grading container tries to send a massive feedback dump back to the MOOC-Grader, the ``/container-post`` view fails to receive it due to ``settings.DATA_UPLOAD_MAX_MEMORY_SIZE``. This fix sets the ``feedback_size_error`` field to ``true`` and empties the feedback file when it is too large. MOOC-Grader can then detect these cases and provide informative feedback to the students.

Part of https://github.com/apluslms/mooc-grader/issues/146

# Testing

**What type of test did you run?**

- [ ] Accessibility test using the [WAVE](https://wave.webaim.org/extension/) extension.
- [ ] Django unit tests.
- [ ] Selenium tests.
- [ ] Other test. *(Add a description below)*
- [x] Manual testing.

Tested that submissions with very large feedback now display an informative error message in A+ instead of getting stuck in grading.

**Did you test the changes in**

- [x] Chrome
- [ ] Firefox
- [ ] This pull request cannot be tested in the browser.

# Translation

- [ ] Did you modify or add new strings in the user interface? ([Read about how to create translation](https://github.com/apluslms/a-plus/tree/master/doc#running-tests-and-updating-translations))

# Programming style

- [x] Did you follow our [style guides](https://apluslms.github.io/contribute/styleguides/)?
- [ ] Did you use Python type hinting in all functions that you added or edited? ([type hints](https://docs.python.org/3/library/typing.html) for function parameters and return values)

# Have you updated the README or other relevant documentation?

- [ ] documents inside the doc directory.
- [ ] README.md.
- [ ] Aplus Manual.
- [ ] Other documentation (mention below which documentation).

# Is it Done?

- [ ] Reviewer has finished the code review
- [ ] After the review, the developer has made changes accordingly
- [ ] Customer/Teacher has accepted the implementation of the feature
