### PR TITLE
Possible bug: errors interpreted as a submission tag

### DIFF
--- a/bin/grade
+++ b/bin/grade
@@ -133,7 +133,7 @@ collect_grading_data() {
     # add grading data to feedback post
     if [ "$grading_options" ]; then
         # NOTE: jo can create json and jq could be used to merge multiple files
-        jo "$grading_options" > $grading_data_file
+        jo $grading_options > $grading_data_file
         opts="$opts -F grading_data=<$grading_data_file"
     fi
 }


### PR DESCRIPTION
When I tried to submit a certain assignment to the O1 course with locally run A+, when checking the result with API, the grading_data looked as follows:
<img width="1141" alt="tag_and_errs" src="https://github.com/user-attachments/assets/e376ae39-3959-4248-84da-019de33ddf7b" />

I assume this is unintentional, as errors never gets transformed into JSON, additionally not showing full errors and being lumped together with the last tag of the submission, like 'warn' in this case. If the tag has been set for the course, I received the following error: 
<img width="568" alt="tag_not_found" src="https://github.com/user-attachments/assets/70e1aedf-106e-4c92-8d58-653a08c133c8" />

Removing the quotation marks seems to fix this, and a-plus/exercise/async_views.py can subsequently find tags after they have been set in the course. I've tested this with a submission that sets tags and returns errors and with a submission that returned tags with no errors. The result looked as follows: 
<img width="1138" alt="sub_no_errs" src="https://github.com/user-attachments/assets/d98ad6ac-ed7c-441b-931a-8e7a8da1d6df" />
<img width="1141" alt="sub_tag_errs" src="https://github.com/user-attachments/assets/b7a39236-77da-456d-ad67-502ccdbfebea" />

I assume this is how it was intended to be used, and there were no more errors shown by async_views.py.